### PR TITLE
ci: add type checking and dependabot for actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,13 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e .
-          pip install pytest pytest-cov flake8 bandit pip-audit
+          pip install pytest pytest-cov flake8 bandit pip-audit pyright
 
       - name: Lint
         run: flake8 src/ --max-line-length=88 --max-complexity=10
+
+      - name: Type check
+        run: pyright src/
 
       - name: Security scan
         run: |


### PR DESCRIPTION
## Summary
- run Pyright type checking in CI workflow
- extend Dependabot to monitor GitHub Actions updates

## Testing
- `pre-commit run --files .github/workflows/ci.yml .github/dependabot.yml`
- `pytest` *(fails: assert 0 == 1, AttributeError: module 'json' has no attribute 'JSONEncodeError', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6894d35a012083278b8082780f229261